### PR TITLE
Slight modification to the GPS submission logic

### DIFF
--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -85,6 +85,8 @@ uint16_t vcc = 0;
 #ifdef WITH_LUX
 uint16_t lux = 0;
 #endif
+int32_t lat24 = 0;
+int32_t lng24 = 0;
 
 // define various pins
 uint8_t const SW_GND_PIN = 20;
@@ -312,19 +314,15 @@ void queueData() {
 
   packet.append(FIRMWARE_VERSION, 8);
   if (gps_data.valid.location && gps_data.valid.status && gps_data.status >= gps_fix::STATUS_STD) {
-    // pack geoposition
-    int32_t lat24 = int32_t((int64_t)gps_data.latitudeL() * 32768 / 10000000);
-    packet.append(lat24, 24);
-
-    int32_t lng24 = int32_t((int64_t)gps_data.longitudeL() * 32768 / 10000000);
-    packet.append(lng24, 24);
-  } else {
-    // Append zeroes if the location is unknown (but do not use the
-    // lat/lon from gps_data, since they might still contain old
-    // values).
-    packet.append(0, 24);
-    packet.append(0, 24);
+    // If valid GPS data has been aquired, update geo variables.
+    // If not, the variables will be left untouched.
+    lat24 = int32_t((int64_t)gps_data.latitudeL() * 32768 / 10000000);
+    lng24 = int32_t((int64_t)gps_data.longitudeL() * 32768 / 10000000);
   }
+
+  // pack coordinates (new if updated, previous values if not)
+  packet.append(lat24, 24);
+  packet.append(lng24, 24);
 
   // pack temperature and humidity
   int16_t tmp16 = temperature * 16;


### PR DESCRIPTION
If unable to acquire a valid GPS fix, the station will now use the previous values instead.