### PR TITLE
MJS2020: Skip SPS30 and GPS when battery is low (and related improvements)

### DIFF
--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -137,6 +137,9 @@ NMEAGPS gps;
 float temperature;
 float humidity;
 uint16_t vcc = 0;
+uint16_t vbatt = 0;
+uint16_t vsolar = 0;
+
 #ifdef WITH_LUX
 uint32_t lux = 0;
 #endif
@@ -396,6 +399,10 @@ void loop() {
 #ifdef WITH_LUX
   lux = readLux();
 #endif // WITH_LUX
+  if (BATTERY_DIVIDER_RATIO)
+    vbatt = readVbatt();
+  if (SOLAR_DIVIDER_RATIO)
+    vsolar = readVsolar();
 #if defined(WITH_SPS30_I2C)
   writeLed(0xff00ff); // purple
   sps30_data = readSps30();
@@ -651,7 +658,7 @@ void queueData() {
 
   if (BATTERY_DIVIDER_RATIO) {
     // Encoded in units of 20mv
-    uint8_t batt = readVbatt() / 20;
+    uint8_t batt = vbatt / 20;
     // Shift down, zero means 1V now
     if (batt >= 50)
       packet.append(batt - 50, 8);
@@ -690,9 +697,8 @@ void queueData() {
 
   if (SOLAR_DIVIDER_RATIO) {
     // Encoded in units of 1mv
-    uint16_t solar = readVsolar();
     packet.append(SOLAR_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-    packet.append(solar, SOLAR_EXTRA_FIELD_BITS);
+    packet.append(vsolar, SOLAR_EXTRA_FIELD_BITS);
   }
 
   // Prepare upstream data transmission at the next possible time.

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -15,6 +15,7 @@
  *******************************************************************************/
 
 // include external libraries
+#include <Arduino.h>
 #include <SPI.h>
 #include <Wire.h>
 #include <SparkFunHTU21D.h>
@@ -173,6 +174,26 @@ uint32_t updatesBeforeGpsUpdate = 0;
 gps_fix gps_data;
 
 uint8_t const LORA_PORT = 13;
+
+/**
+ * Forward declarations for functions. Not strictly needed for Arduino,
+ * but makes the code easier to use with IDEs that do less
+ * preprocessing.
+ */
+void doSleep(uint32_t time);
+void dumpData();
+void getPosition();
+void queueData();
+uint16_t readVcc();
+uint16_t readVsolar();
+uint16_t readVbatt();
+#ifdef WITH_LUX
+uint32_t readLux():
+#endif // WITH_LUX
+#ifdef WITH_SPS30_I2C
+struct sps30_measurement readSps30();
+#endif // WITH_SPS30_I2C
+void writeLed(uint32_t rgb);
 
 #if defined(SERIAL_IS_SERIALUSB) || defined(SERIAL_IS_CONFIGURABLE)
 bool wait_for_usb_configured(unsigned long timeout) {

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -626,6 +626,16 @@ void getPosition()
   GPS_SERIAL.end();
 }
 
+/**
+ * Append an extra field to a packet being built.
+ */
+void appendExtra(BitStream& packet, uint32_t value, size_t bits) {
+  // First add the size of the field (minus one to allow a size of 1-32
+  // rather than 0-31).
+  packet.append(bits-1, EXTRA_SIZE_BITS);
+  packet.append(value, bits);
+}
+
 void queueData() {
   uint8_t length = 12;
   uint8_t flags = 0;
@@ -709,34 +719,23 @@ uint8_t extra_bits = 0;
   }
 
 #ifdef WITH_SPS30_I2C
-  // Append extra fields. For each field, first add the size of the
-  // field (minus one to allow a size of 1-32 rather than 0-31).
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  // Append extra fields
+  appendExtra(packet, sps30_data.mc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.mc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.mc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.mc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
 
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.nc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.nc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.nc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.nc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
 
-  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.typical_particle_size * 1000 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  appendExtra(packet, sps30_data.typical_particle_size * 1000 + 0.5, SPS30_EXTRA_FIELD_BITS);
 #endif // WITH_SPS30_I2C
 
   if (SOLAR_DIVIDER_RATIO) {
     // Encoded in units of 1mv
-    packet.append(SOLAR_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-    packet.append(vsolar, SOLAR_EXTRA_FIELD_BITS);
+    appendExtra(packet, vsolar, SOLAR_EXTRA_FIELD_BITS);
   }
 
   // Fill any remaining bits (from rounding up to whole bytes) with 1's,

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -342,7 +342,7 @@ void setup() {
     Serial.print("NC 10.0: ");
     Serial.println(sps30_data.nc_10p0);
 
-    Serial.print("Typical partical size: ");
+    Serial.print("Typical particle size: ");
     Serial.println(sps30_data.typical_particle_size);
 #endif // defined(WITH_SPS30_I2C)
 

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -295,6 +295,10 @@ void setup() {
   if (DEBUG) {
     temperature = htu.readTemperature();
     humidity = htu.readHumidity();
+    if (BATTERY_DIVIDER_RATIO)
+      vbatt = readVbatt();
+    if (SOLAR_DIVIDER_RATIO)
+      vsolar = readVsolar();
     vcc = readVcc();
 #ifdef WITH_LUX
     lux = readLux();
@@ -317,6 +321,18 @@ void setup() {
     Serial.println(temperature);
     Serial.print(F("Humidity: "));
     Serial.println(humidity);
+    if (BATTERY_DIVIDER_RATIO) {
+      Serial.print(F("Battery Divider Ratio: "));
+      Serial.println(BATTERY_DIVIDER_RATIO);
+      Serial.print(F("Vbatt: "));
+      Serial.println(vbatt);
+    }
+    if (SOLAR_DIVIDER_RATIO) {
+      Serial.print(F("Solar Divider Ratio: "));
+      Serial.println(SOLAR_DIVIDER_RATIO);
+      Serial.print(F("Vsolar: "));
+      Serial.println(vsolar);
+    }
     Serial.print(F("Vcc: "));
     Serial.println(vcc);
 #ifdef WITH_LUX
@@ -349,14 +365,6 @@ void setup() {
     Serial.println(sps30_data.typical_particle_size);
 #endif // defined(WITH_SPS30_I2C)
 
-    if (BATTERY_DIVIDER_RATIO) {
-      Serial.print(F("Battery Divider Ratio: "));
-      Serial.println(BATTERY_DIVIDER_RATIO);
-    }
-    if (SOLAR_DIVIDER_RATIO) {
-      Serial.print(F("Solar Divider Ratio: "));
-      Serial.println(SOLAR_DIVIDER_RATIO);
-    }
     Serial.flush();
   }
 

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -650,10 +650,8 @@ void queueData() {
 #endif
 
   if (BATTERY_DIVIDER_RATIO) {
-    analogReference(BATTERY_DIVIDER_REF);
-    uint16_t reading = analogRead(BATTERY_DIVIDER_PIN);
     // Encoded in units of 20mv
-    uint8_t batt = (uint32_t)(reading*BATTERY_DIVIDER_RATIO*BATTERY_DIVIDER_REF_MV)/(20*1023);
+    uint8_t batt = readVbatt() / 20;
     // Shift down, zero means 1V now
     if (batt >= 50)
       packet.append(batt - 50, 8);
@@ -691,10 +689,8 @@ void queueData() {
 #endif // WITH_SPS30_I2C
 
   if (SOLAR_DIVIDER_RATIO) {
-    analogReference(SOLAR_DIVIDER_REF);
-    uint16_t reading = analogRead(SOLAR_DIVIDER_PIN);
     // Encoded in units of 1mv
-    uint16_t solar = (uint32_t)(reading*SOLAR_DIVIDER_RATIO*SOLAR_DIVIDER_REF_MV)/1023;
+    uint16_t solar = readVsolar();
     packet.append(SOLAR_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
     packet.append(solar, SOLAR_EXTRA_FIELD_BITS);
   }
@@ -746,6 +742,19 @@ uint16_t readVcc()
   return STM32L0.getVDDA() * 1000;
   #endif
 }
+
+uint16_t readVsolar() {
+    analogReference(SOLAR_DIVIDER_REF);
+    uint16_t reading = analogRead(SOLAR_DIVIDER_PIN);
+    return (uint32_t)(reading*SOLAR_DIVIDER_RATIO*SOLAR_DIVIDER_REF_MV)/1023;
+}
+
+uint16_t readVbatt() {
+    analogReference(BATTERY_DIVIDER_REF);
+    uint16_t reading = analogRead(BATTERY_DIVIDER_PIN);
+    return (uint32_t)(reading*BATTERY_DIVIDER_RATIO*BATTERY_DIVIDER_REF_MV)/1023;
+}
+
 
 #ifdef WITH_LUX
 uint32_t readLux()

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -651,8 +651,8 @@ void queueData() {
   // This allows up to 6553.5 μg/m³ (datasheet says up to 1000), up to
   // 6553.5 #/cm³ (datasheet says up to 3000) and up to
   // 65535 nm typical particle size (datasheet suggests up to 10).
-  const uint8_t EXTRA_FIELD_BITS = 15;
-  const uint8_t extra_bits = 9*(EXTRA_SIZE_BITS+EXTRA_FIELD_BITS);
+  const uint8_t SPS30_EXTRA_FIELD_BITS = 15;
+  const uint8_t extra_bits = 9*(EXTRA_SIZE_BITS+SPS30_EXTRA_FIELD_BITS);
   length += (extra_bits + 7)/8;
   flags |= FLAG_WITH_EXTRA;
 #endif // WITH_SPS30_I2C
@@ -705,27 +705,27 @@ void queueData() {
 
 #ifdef WITH_SPS30_I2C
   // Append extra fields. For each field, first add the size of the
-  // field (minus on to allow a size of 1-32 rather than 0-31).
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_1p0 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_2p5 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_4p0 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.mc_10p0 * 10 + 0.5, EXTRA_FIELD_BITS);
+  // field (minus one to allow a size of 1-32 rather than 0-31).
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.mc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.mc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.mc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.mc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
 
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_1p0 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_2p5 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_4p0 * 10 + 0.5, EXTRA_FIELD_BITS);
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.nc_10p0 * 10 + 0.5, EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.nc_1p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.nc_2p5 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.nc_4p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.nc_10p0 * 10 + 0.5, SPS30_EXTRA_FIELD_BITS);
 
-  packet.append(EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
-  packet.append(sps30_data.typical_particle_size * 1000 + 0.5, EXTRA_FIELD_BITS);
+  packet.append(SPS30_EXTRA_FIELD_BITS-1, EXTRA_SIZE_BITS);
+  packet.append(sps30_data.typical_particle_size * 1000 + 0.5, SPS30_EXTRA_FIELD_BITS);
 
   // Fill any remaining bits (from rounding up to whole bytes) with 1's,
   // so they cannot be a valid field.

--- a/mjs_firmware.ino
+++ b/mjs_firmware.ino
@@ -516,6 +516,14 @@ void dumpData() {
   Serial.print(temperature, 1);
   Serial.print(F(", hum="));
   Serial.print(humidity, 1);
+  if (BATTERY_DIVIDER_RATIO) {
+    Serial.print(", vbatt=");
+    Serial.print(vbatt);
+  }
+  if (SOLAR_DIVIDER_RATIO) {
+    Serial.print(", vsolar=");
+    Serial.print(vsolar);
+  }
   Serial.print(F(", vcc="));
   Serial.print(vcc, 1);
 #ifdef WITH_LUX


### PR DESCRIPTION
This PR contains some work based on improvements by @Peter-dM, but split into multiple commits and with some additional changes from my side.

The primary change that motivated this PR is the last commit, which ensures that when the battery voltage becomes low, the SPS30 and GPS readouts are skipped, limiting the readings to only the more low-power sensors. For nodes that run on solar, this should ensure that even in bad solar conditions, the node will never completely run out of battery.

There are a number of other changes making the battery and solar readouts a bit more consistent. Additionally, there is a commit that compresses the transmission of extra fields by not transmitting leading zero bits.